### PR TITLE
feat: implement clock in to upcoming shift only

### DIFF
--- a/lib/presentation/dashboard_screen/widgets/next_shifts.dart
+++ b/lib/presentation/dashboard_screen/widgets/next_shifts.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:suprsync/presentation/dashboard_screen/auth/controller/auth_controller.dart';
+import 'package:suprsync/presentation/dashboard_screen/clockin_page/clockin_controller.dart';
+
+class ShiftCard extends StatelessWidget {
+  const ShiftCard({
+    super.key,
+    required this.time,
+    required this.day,
+    required this.id,
+    required this.branch,
+    required this.hexCode,
+  });
+
+  final String id;
+  final String time;
+  final String day;
+  final String branch;
+  final String hexCode;
+
+  @override
+  Widget build(BuildContext context) {
+    final ClockInAndOutController _clockInController = Get.find();
+    final AuthController _authController = Get.find();
+    Size size = MediaQuery.of(context).size;
+    return Card(
+      elevation: 0,
+      color: const Color(0xffFBFBFB),
+      shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(5.0),
+          side: const BorderSide(color: Color(0xffF5F5F5))),
+      child: IntrinsicHeight(
+        child: Row(
+          children: [
+            const ClipRRect(
+              borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(50),
+                  bottomLeft: Radius.circular(50)),
+              child: VerticalDivider(
+                color: Colors.black,
+                width: 5,
+                thickness: 8,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(left: 13.0, top: 13),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    time.removeAllWhitespace,
+                    style: context.textTheme.labelMedium
+                        ?.copyWith(color: const Color(0xE59A9A9A)),
+                  ),
+                  const SizedBox(
+                    height: 4,
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        '8hrs',
+                        style: context.textTheme.titleMedium?.copyWith(
+                            fontSize: 14, color: const Color(0xff8E8E90)),
+                      ),
+                      SizedBox(
+                        width: size.width * 0.6,
+                      ),
+                      Text(
+                        branch,
+                        style: context.textTheme.labelSmall
+                            ?.copyWith(color: Color(int.parse("0xff$hexCode"))),
+                        // textAlign: Ali,
+                      )
+                    ],
+                  ),
+                  const SizedBox(
+                    height: 10,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/dashboard_screen/widgets/swap_cards.dart
+++ b/lib/presentation/dashboard_screen/widgets/swap_cards.dart
@@ -5,7 +5,7 @@ import 'package:suprsync/core/utils/show_snackbar.dart';
 import 'package:suprsync/presentation/dashboard_screen/auth/controller/auth_controller.dart';
 import 'package:suprsync/presentation/dashboard_screen/clockin_page/clockin_controller.dart';
 import 'package:suprsync/presentation/dashboard_screen/clockin_page/clockin_page.dart';
-import 'package:suprsync/presentation/dashboard_screen/schedules/swap_screen.dart';
+import 'package:suprsync/presentation/dashboard_screen/schedules/shedules_controller/available_shifts_controller.dart';
 
 class SwapCard extends StatelessWidget {
   const SwapCard(
@@ -160,31 +160,29 @@ class SwapCard extends StatelessWidget {
                   const SizedBox(
                     height: 10,
                   ),
-                  !isOpenForSwap
-                      ? Obx(() {
-                          _clockInController.swapId.value;
-                          return GestureDetector(
-                            onTap: () {
-                              _clockInController.swapId.value = id;
-                              // Get.to(() => const SwapScreen());
-                            },
-                            child: Container(
-                              color: const Color(0xffFFFFFF),
-                              height: 50,
-                              child: Padding(
-                                padding: const EdgeInsets.symmetric(
-                                    horizontal: 10.0, vertical: 14),
-                                child: Text(
-                                  isOpenForSwap
-                                      ? 'Open for Swap'
-                                      : 'Closed for swap',
-                                  style: context.textTheme.labelMedium,
-                                ),
-                              ),
-                            ),
-                          );
-                        })
-                      : const SizedBox(),
+                  Obx(() {
+                    _clockInController.swapId.value;
+                    return GestureDetector(
+                      onTap: () {
+                        _clockInController.swapId.value = id;
+                        print(_clockInController.swapId.value);
+
+                        // Get.to(() => const SwapScreen());
+                      },
+                      child: Container(
+                        color: const Color(0xffFFFFFF),
+                        height: 50,
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 10.0, vertical: 14),
+                          child: Text(
+                            isOpenForSwap ? 'Open for Swap' : 'Closed for swap',
+                            style: context.textTheme.labelMedium,
+                          ),
+                        ),
+                      ),
+                    );
+                  })
                 ],
               ),
             ],
@@ -200,6 +198,7 @@ class SwapCard extends StatelessWidget {
     final buttonWidth = renderBox.size.width;
     final buttonHeight = renderBox.size.height - 100;
     print('your shift Id 2 is $shiftId');
+    final ShiftController _shiftsController = Get.find();
 
     // Show the menu to the right of the button
     showMenu(
@@ -228,6 +227,7 @@ class SwapCard extends StatelessWidget {
           onTap: () {
             if (isSwappable) {
               // Get.to(() => SwapScreen());
+              // _shiftsController.swapShift(shiftId);
             } else {
               showSnackBar('This shift is not swappable');
             }


### PR DESCRIPTION
This allows staffs to clock in to the latest upcoming shift only. And until she shift is over, they can't clock into the next.